### PR TITLE
Remove Sonar analysis from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,3 @@ dist: clean build package
 .PHONY: publish
 publish:
 	mvn jar:jar deploy:deploy
-
-.PHONY: sonar
-sonar:
-	mvn sonar:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,8 @@
         <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
         <artifactoryResolveRepo>libs-release-local</artifactoryResolveRepo>
         <artifactorySnapshotRepo>libs-snapshot-local</artifactorySnapshotRepo>
-        
-        <!-- Sonar -->
-        <sonar-maven-plugin.version>3.4.0.905</sonar-maven-plugin.version>
-        <sonar.host.url>${CODE_ANALYSIS_HOST_URL}</sonar.host.url>
-        <sonar.login>${CODE_ANALYSIS_LOGIN}</sonar.login>
-        <sonar.password>${CODE_ANALYSIS_PASSWORD}</sonar.password>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
This repo contains no non-auto-generated code or unit tests so the test coverage shows at 0% on the coverage report. The Sonar analysis is not required and can be removed.