### PR TITLE
GCI-931: Send order details to certificates team

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,9 @@
                                 <include>document-generation-started.avsc</include>
                                 <include>document-generation-completed.avsc</include>
                                 <include>document-generation-failed.avsc</include>
+                                <include>email-send.avsc</include>
                                 <include>filing-processed.avsc</include>
                                 <include>filing-received.avsc</include>
-                                <include>message-send.avsc</include>
                                 <include>order-received.avsc</include>
                                 <include>render-submitted-data-document.avsc</include>
                                 <include>secure-application-completed.avsc</include>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
                                 <include>document-generation-failed.avsc</include>
                                 <include>filing-processed.avsc</include>
                                 <include>filing-received.avsc</include>
+                                <include>message-send.avsc</include>
                                 <include>order-received.avsc</include>
                                 <include>render-submitted-data-document.avsc</include>
                                 <include>secure-application-completed.avsc</include>


### PR DESCRIPTION
* This PR simply brings the `email-send` schema into those schemas for which type safe Java classes are generated, so that `item-handler` can use the generated `email-send` class. 