### PR TITLE
GCI-1434: Generate model classes for the chd-item-ordered schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
                             <stringType>String</stringType>
                             <sourceDirectory>${project.basedir}/chs-kafka-schemas/schemas</sourceDirectory>
                             <includes>
+                                <include>chd-item-ordered.avsc</include>
                                 <include>compliance-action-completed.avsc</include>
                                 <include>document-generation-started.avsc</include>
                                 <include>document-generation-completed.avsc</include>


### PR DESCRIPTION
* Update this `kafka-models` project to depend on the latest `master` branch image of `chs-kafka-schemas`.
* Add `chd-item-ordered.avsc` to those schemas for which Java model classes are generated.