### PR TITLE
BI-6488 Build java model from schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
                             <sourceDirectory>${project.basedir}/chs-kafka-schemas/schemas</sourceDirectory>
                             <includes>
                                 <include>chd-item-ordered.avsc</include>
+                                <include>chips-rest-interfaces-send.avsc</include>
                                 <include>compliance-action-completed.avsc</include>
                                 <include>document-generation-started.avsc</include>
                                 <include>document-generation-completed.avsc</include>


### PR DESCRIPTION
For chips rest interfaces consumer:

Updated submodule 
Updated pom
in order to build java model ready for use by the java ch-kafka module 