### PR TITLE
DCAC-68: Generate model classes for the item-ordered-certified-copy schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
                                 <include>email-send.avsc</include>
                                 <include>filing-processed.avsc</include>
                                 <include>filing-received.avsc</include>
+                                <include>item-ordered-certified-copy.avsc</include>
                                 <include>order-received.avsc</include>
                                 <include>order-received-notification-retry.avsc</include>
                                 <include>render-submitted-data-document.avsc</include>


### PR DESCRIPTION
* Pull in the merged image of the `chs-kafka-schemas` submodule with the new `item-ordered-certified-copy` schema.
* Include the new schema in the list of those from which Java Kafka message model objects are generated.