### PR TITLE
DCAC-254: Add missing item-group-ordered.avsc to schemas built (Java 17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
                                 <include>email-send.avsc</include>
                                 <include>filing-processed.avsc</include>
                                 <include>filing-received.avsc</include>
+                                <include>item-group-ordered.avsc</include>
                                 <include>item-ordered-certified-copy.avsc</include>
                                 <include>order-received.avsc</include>
                                 <include>order-received-notification-retry.avsc</include>


### PR DESCRIPTION
* Somehow lost this change in the mêlée.  
* Need it to get the `ItemGroupOrdered` et al Kafka Avro DTO classes generated.