### PR TITLE
DCAC-80: Bring item-group-processed into models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
                                 <include>filing-processed.avsc</include>
                                 <include>filing-received.avsc</include>
                                 <include>item-group-ordered.avsc</include>
+                                <include>item-group-processed.avsc</include>
                                 <include>item-group-processed-send.avsc</include>
                                 <include>item-ordered-certified-copy.avsc</include>
                                 <include>order-received.avsc</include>


### PR DESCRIPTION
* Bring in the new `item-group-processed` schema to generate the corresponding `ItemGroupProcessed` et al Avro DTO classes. 