### PR TITLE
Updated Apache Commons FileUpload to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.7.2</version>
+            <version>4.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>


### PR DESCRIPTION

# Vulnerabilities Fixed 

## CVE-2025-48976 - commons-fileupload-1.5.jar

https://ossindex.sonatype.org/vulnerability/CVE-2025-48976

### Fix

Updated Apache Commons File Upload from 1.5 to 1.6.0

```diff
        <dependency>
            <groupId>commons-fileupload</groupId>
            <artifactId>commons-fileupload</artifactId>
-            <version>1.5</version>
+            <version>1.6.0</version>
        </dependency>
```

## CVE-2025-27817 - kafka-clients-3.9.0.jar

https://ossindex.sonatype.org/vulnerability/CVE-2025-27817

### Fix 

Updated Apache Kafka from 3.7.2 to 4.0.0

```diff
        <dependency>
            <groupId>org.apache.kafka</groupId>
            <artifactId>kafka-clients</artifactId>
-            <version>3.7.2</version>
+            <version>4.0.0</version>
```
