### PR TITLE
[KAF-251] feat: address  CVE-2023-35116

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,43 +7,29 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.12</version>
+        <version>2.1.14</version>
         <relativePath/>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <avro.version>1.11.4</avro.version>
-        <avro-maven-plugin.version>1.11.4</avro-maven-plugin.version>
+        <avro.version>1.11.5</avro.version>
+        <avro-maven-plugin.version>1.11.5</avro-maven-plugin.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
-        <artifactoryResolveRepo>libs-release-local</artifactoryResolveRepo>
-        <artifactorySnapshotRepo>libs-snapshot-local</artifactorySnapshotRepo>
-        <wiremock.standalone.version>2.35.1</wiremock.standalone.version>
         <jackson-databind.version>2.16.2</jackson-databind.version>
-        <commons-compress.version>1.27.1</commons-compress.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
         <junit-jupiter-engine.version>5.10.5</junit-jupiter-engine.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <mockito-junit-jupiter.version>5.5.0</mockito-junit-jupiter.version>
         <assertj-core.version>3.24.2</assertj-core.version>
-        <kafka-clients.version>4.0.0</kafka-clients.version>
-        <snappy-java.version>1.1.10.8</snappy-java.version>
+        <kafka-clients.version>4.0.2</kafka-clients.version>
         <jackson-core.version>2.15.4</jackson-core.version>
         <commons-fileupload.version>1.6.0</commons-fileupload.version>
-        <guava.version>32.1.2-jre</guava.version>
-        <jetty-http.version>12.0.27</jetty-http.version>
-        <jetty-server.version>12.0.27</jetty-server.version>
         <json-smart.version>2.5.2</json-smart.version>
-        <jetty-xml.version>12.0.27</jetty-xml.version>
-        <jetty-client.version>12.0.27</jetty-client.version>
         <mockito-core.version>5.7.0</mockito-core.version>
         <byte-buddy.version>1.14.19</byte-buddy.version>
-        <jetty-ee10-webapp.version>12.0.27</jetty-ee10-webapp.version>
-        <wiremock-jetty12.version>3.13.1</wiremock-jetty12.version>
         <android-json.version>0.0.20131108.vaadin1</android-json.version>
-        <structured-logging.version>3.0.41</structured-logging.version>
+        <structured-logging.version>3.0.54</structured-logging.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven.replacer.plugin.version>1.5.3</maven.replacer.plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
@@ -63,44 +49,21 @@
         <sonar.jacoco.reports>${project.build.directory}/site</sonar.jacoco.reports>
         <sonar.java.binaries>${project.basedir}/target,${project.basedir}/target/*</sonar.java.binaries>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <!--CVE-2023-35116-->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>${commons-compress.version}</version>
-            <!-- Excluded to mitigate CVE-2025-48924 until common-compress upgrades commons-lang3 -->
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- Explicitly included CVE-2025-48924 fixed version of commons-lang3 to override the excluded transitive dependency -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -130,17 +93,6 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka-clients.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.xerial.snappy</groupId>
-                    <artifactId>snappy-java</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${snappy-java.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -153,37 +105,6 @@
             <version>${commons-fileupload.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-http -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-http</artifactId>
-            <version>${jetty-http.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>${json-smart.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-xml</artifactId>
-            <version>${jetty-xml.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-client</artifactId>
-            <version>${jetty-client.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${jetty-server.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito-core.version}</version>
@@ -194,27 +115,6 @@
             <artifactId>byte-buddy</artifactId>
             <version>${byte-buddy.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.ee10</groupId>
-            <artifactId>jetty-ee10-webapp</artifactId>
-            <version>${jetty-ee10-webapp.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wiremock</groupId>
-            <artifactId>wiremock-jetty12</artifactId>
-            <version>${wiremock-jetty12.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.networknt</groupId>
-                    <artifactId>json-schema-validator</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.javacrumbs.json-unit</groupId>
-                    <artifactId>json-unit-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.vaadin.external.google</groupId>


### PR DESCRIPTION
  removed a number of unused dependencies from the service:
    - Guava
    - jetty-http
    - snappy-java
    - commons-lang3